### PR TITLE
Add libest-dist image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+libest-dist.tar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,60 @@
+name: Publish libEST
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Building libEST
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build libest-builder image
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        tags: libest-builder
+        target: libest-builder
+
+    - name: Build libest-dist image
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        tags: libest-dist
+        target: libest-dist
+        outputs: type=docker,dest=libest-dist.tar
+
+    - name: Store libest-dist image
+      uses: actions/cache@v3
+      with:
+        key: libest-dist-${{ github.sha }}
+        path: libest-dist.tar
+
+  publish:
+    name: Publishing libEST
+    if: github.event_name == 'push' && github.ref_name == 'v3.2.0-pki'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Log in to the Container registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Retrieve libest-dist image
+      uses: actions/cache@v3
+      with:
+        key: libest-dist-${{ github.sha }}
+        path: libest-dist.tar
+
+    - name: Publish libest-dist image
+      run: |
+        docker load --input libest-dist.tar
+        docker tag libest-dist ghcr.io/${{ github.repository_owner }}/libest-dist:latest
+        docker push ghcr.io/${{ github.repository_owner }}/libest-dist:latest

--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>libest</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+################################################################################
+FROM registry.fedoraproject.org/fedora:latest AS libest-builder
+
+# Install build tools
+RUN dnf install -y dnf-plugins-core rpm-build
+
+# Import libEST source
+COPY . /root/libest/
+WORKDIR /root/libest
+
+# Create source tarball
+RUN mkdir -p /root/rpmbuild/SOURCES
+RUN tar czvf /root/rpmbuild/SOURCES/libest-3.2.0-pki.tar.gz \
+    --transform "s,^./,libest-3.2.0-pki/," \
+    --exclude .git \
+    -C /root/libest \
+    .
+
+# Install build dependencies
+RUN dnf builddep -y --spec libest.spec
+
+# Build libEST packages
+RUN rpmbuild -ba libest.spec
+
+# Consolidate libEST packages
+RUN mkdir -p /root/RPMS
+RUN find /root/rpmbuild/RPMS -mindepth 2 -type f -exec mv {} /root/RPMS \;
+
+################################################################################
+FROM alpine:latest AS libest-dist
+
+# Import libEST packages
+COPY --from=libest-builder /root/RPMS /root/RPMS/

--- a/example/client/estclient.c
+++ b/example/client/estclient.c
@@ -1279,12 +1279,9 @@ int main (int argc, char **argv)
                 est_port = atoi(optarg);
                 break;
             case 'f':
-                /* Turn FIPS on if requested and exit if failure */
-                set_fips_return = FIPS_mode_set(1);
-                if (!set_fips_return) {
-                    printf("\nERROR setting FIPS MODE ON ...\n");
-                    ERR_load_crypto_strings();
-                    ERR_print_errors(BIO_new_fp(stderr,BIO_NOCLOSE));
+                /* Ensure FIPS mode is on */
+                if (!FIPS_mode()) {
+                    printf("\nERROR FIPS required, but disabled...\n");
                     exit(1);
                 } else {
                     printf("\nRunning EST Sample Client with FIPS MODE = ON\n");

--- a/example/proxy/estproxy.c
+++ b/example/proxy/estproxy.c
@@ -590,17 +590,12 @@ int main (int argc, char **argv)
             listen_port = atoi(optarg);
             break;
         case 'f':
-            /*
-             * Turn FIPS on if user requested it and exit if failure
-             */
-            set_fips_return = FIPS_mode_set(1);
-            if (set_fips_return != 1) {
-                set_fips_error = ERR_get_error();
-                printf("\nERROR WHILE SETTING FIPS MODE ON exiting ....\n");
+            if (!FIPS_mode()) {
+                printf("\nERROR FIPS required, but disabled...\n");
                 exit(1);
             } else {
                 printf("\nRunning EST Sample Proxy with FIPS MODE = ON !\n");
-            }
+            };
             break;
         default:
             show_usage_and_exit();

--- a/example/server/estserver.c
+++ b/example/server/estserver.c
@@ -2273,18 +2273,13 @@ int main (int argc, char **argv)
             strncpy(realm, optarg, MAX_REALM_LEN);
             break;
         case 'f':
-            /* turn FIPS on if user requested it
-             * and exit if failure.
-             */
-            set_fips_return = FIPS_mode_set(1);
-            if (set_fips_return != 1) {
-                set_fips_error = ERR_get_error();
-                printf("\nERROR WHILE SETTING FIPS MODE ON exiting ....\n");
+            /* Ensure FIPS mode is on */
+            if (!FIPS_mode()) {
+                printf("\nERROR FIPS required, but disabled...\n");
                 exit(1);
             } else {
                 printf("\nRunning EST Sample Server with FIPS MODE = ON !\n");
-            }
-            ;
+            };
             break;
         default:
             show_usage_and_exit();

--- a/libest.spec
+++ b/libest.spec
@@ -1,0 +1,61 @@
+# %%global _prefix /opt
+
+Name:           libest
+Version:        3.2.0
+Release:        1%{?dist}
+Summary:        EST stack written in C
+
+License:        LGPLv2+
+URL:            https://github.com/dogtagpki/libest
+Source:         https://github.com/dogtagpki/%{name}/archive/v%{version}-pki/%{name}-%{version}-pki.tar.gz
+
+BuildRequires: gcc
+BuildRequires: make
+BuildRequires: autoconf automake libtool
+BuildRequires: openssl-devel
+%description
+libest project is an EST stack written in C.
+EST is used for secure certificate enrollment and is compatible
+with Suite B certs (as well as RSA and DSA certificates).
+EST is a suitable replacement for SCEP.
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+The package contains libraries and header files for
+developing applications that use libest.
+
+%prep
+%setup -n libest-%{version}-pki
+
+%build
+%configure --disable-safec
+V=1 make %{?_smp_mflags}
+
+%install
+make install DESTDIR=%{buildroot}
+rm -f %{buildroot}/%{_libdir}/*.{a,la}
+mkdir -p %{buildroot}/%{_docdir}/%{name}/example
+find . -type f \( -name "*.c*" -o -name "*.h*" -o -name "*.o" -o -name "estserver" -o -name "Makefile*" \) | xargs rm -rf
+cp -r %{_builddir}/%{name}-%{version}-pki/example/server %{buildroot}/%{_docdir}/%{name}/example
+
+%ldconfig_scriptlets
+
+%files
+%{!?_licensedir:%global license %%doc}
+%license COPYING
+%doc README AUTHORS
+%docdir %{_docdir}/%{name}/example/server
+%doc %{_docdir}/%{name}/example/server
+%exclude %{_docdir}/%{name}/example/server/.libs
+%{_libdir}/lib*.so
+%{_bindir}/est*
+
+%files devel
+%{_includedir}/est/est.h
+
+%changelog
+* Fri Jul 29 2022 Viktor Ashirov <vashirov@redhat.com> - 3.2.0-1
+- Initial release libest-3.2.0

--- a/src/est/est_locl.h
+++ b/src/est/est_locl.h
@@ -590,7 +590,7 @@ typedef struct est_oid_list {
 /*
  * Index used to link the EST Ctx into the SSL structures
  */
-int e_ctx_ssl_exdata_index;
+/* int e_ctx_ssl_exdata_index; */
 
 LIBEST_TEST_API void est_log (EST_LOG_LEVEL lvl, char *format, ...);
 LIBEST_TEST_API void est_log_backtrace (void);


### PR DESCRIPTION
A new GH Workflow has been added to build and publish libEST to GH Packages such that it can be used for CI without a COPR repo. The libEST RPMs will be stored in an Alpine-based image to keep the distribution small. The publishing will be done from `v3.2.0-pki` branch since that branch has been designated to store PKI-specific changes.

This PR includes the spec file (with minor modifications) and patches originally created by @vashirov and @frasertweedale.

See also:
* https://github.com/dogtagpki/libest/wiki
* https://copr.fedorainfracloud.org/coprs/g/pki/libest/